### PR TITLE
Rounding fix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,4 +50,5 @@ fn rounding(sliderval:i32) -> i32 {
             return sliderval+num
         }
     }
+    panic!("for loop failed")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,17 +48,9 @@ fn rounding(sliderval:i32) -> i32 {
     // This rounds sliderval to the nearest 5%, it's not the prettiest thing but it works.
     // I tried to fix this with a for loop (Thank you Capp for the idea) and just
     // iterating through -2..=2 but rust compiler didn't like that.
-    if sliderval%5 == 0 {
-        return sliderval
-    } else {
-        if (sliderval-2)%5 == 0 {
-            return sliderval-2
-        } else if (sliderval-1)%5 == 0 {
-            return sliderval-1
-        } else if (sliderval+2)%5 == 0 {
-            return sliderval+2
-        } else if (sliderval+1)%5 == 0 {
-            return sliderval+1
-        } else {panic!("you set the slider value to a non-number")}
+    for num in -2..=2 {
+        if (sliderval+num)%5 == 0 {
+            return sliderval+num
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,9 +45,6 @@ fn main() -> Result<(), eframe::Error> {
 }
 
 fn rounding(sliderval:i32) -> i32 {
-    // This rounds sliderval to the nearest 5%, it's not the prettiest thing but it works.
-    // I tried to fix this with a for loop (Thank you Capp for the idea) and just
-    // iterating through -2..=2 but rust compiler didn't like that.
     for num in -2..=2 {
         if (sliderval+num)%5 == 0 {
             return sliderval+num


### PR DESCRIPTION
doesn't work rn, if anyone comes across this and knows how to make the compiler stop doing what it's doing I'd appreciate you adding onto this pr.

current output with this code:
```
error[E0308]: mismatched types
  --> src/main.rs:48:5
   |
47 |   fn rounding(sliderval:i32) -> i32 {
   |                                 --- expected `i32` because of return type
48 | /     for num in -2..=2 {
49 | |         if (sliderval+num)%5 == 0 {
50 | |             return sliderval+num
51 | |         }
52 | |     }
   | |_____^ expected `i32`, found `()`
   |
note: the function expects a value to always be returned, but loops might run zero times
  --> src/main.rs:48:5
   |
48 |     for num in -2..=2 {
   |     ^^^^^^^^^^^^^^^^^ this might have zero elements to iterate on
49 |         if (sliderval+num)%5 == 0 {
50 |             return sliderval+num
   |             -------------------- if the loop doesn't execute, this value would never get returned
   = help: return a value for the case when the loop has zero elements to iterate on, or consider changing the return type to account for that possibility

For more information about this error, try `rustc --explain E0308`.
error: could not compile `screenctrl` (bin "screenctrl") due to previous error
```